### PR TITLE
Fix app background color not seamless on iOS 26

### DIFF
--- a/app/(index)/layout.tsx
+++ b/app/(index)/layout.tsx
@@ -7,44 +7,46 @@ import morilinkLogo from "@/public/images/MoriLink_Logo.svg";
 
 export default function HomePageLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex size-full min-h-dvh items-center justify-center bg-dutch-white bg-[radial-gradient(#f4ecca_15%,transparent_15%),radial-gradient(#f4ecca_14%,transparent_14%)] bg-size-[25px_25px] bg-position-[0_0,12.5px_12.5px] bg-repeat">
-      <div className="m-auto grid w-full max-w-100 grid-cols-1 gap-y-2 px-5 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
-        <div className="flex justify-center">
-          <Image src={morilinkLogo} alt={`${app.name} logo`} className="w-40" draggable={false} />
-        </div>
-        <div className="w-full rounded-[5rem] bg-alabaster pt-8.5 pb-9.5">
-          <div className="grid h-full grid-rows-[auto_1fr] gap-y-7.5">
-            <div className="flex items-center px-9 text-sm font-semibold tracking-normal text-bone">
-              <div className="flex grow items-center gap-x-2">
-                <button
-                  className="flex h-5.5 w-9.5 transform items-center justify-center rounded-full bg-bone text-alabaster transition active:scale-90"
-                  type="button"
-                  tabIndex={-1}
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    className="size-4"
-                    viewBox="0 0 20 20"
-                    fill="currentColor"
+    <body className="bg-dutch-white">
+      <div className="flex size-full min-h-dvh items-center justify-center bg-[radial-gradient(#f4ecca_15%,transparent_15%),radial-gradient(#f4ecca_14%,transparent_14%)] bg-size-[25px_25px] bg-position-[0_0,12.5px_12.5px] bg-repeat">
+        <div className="m-auto grid w-full max-w-100 grid-cols-1 gap-y-2 px-5 pt-8 pb-[calc(2rem+env(safe-area-inset-bottom))]">
+          <div className="flex justify-center">
+            <Image src={morilinkLogo} alt={`${app.name} logo`} className="w-40" draggable={false} />
+          </div>
+          <div className="w-full rounded-[5rem] bg-alabaster pt-8.5 pb-9.5">
+            <div className="grid h-full grid-rows-[auto_1fr] gap-y-7.5">
+              <div className="flex items-center px-9 text-sm font-semibold tracking-normal text-bone">
+                <div className="flex grow items-center gap-x-2">
+                  <button
+                    className="flex h-5.5 w-9.5 transform items-center justify-center rounded-full bg-bone text-alabaster transition active:scale-90"
+                    type="button"
+                    tabIndex={-1}
                   >
-                    <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
-                    <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
-                  </svg>
-                </button>
-                <span>{player.name}</span>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      className="size-4"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                    >
+                      <path d="M2.003 5.884L10 9.882l7.997-3.998A2 2 0 0016 4H4a2 2 0 00-1.997 1.884z" />
+                      <path d="M18 8.118l-8 4-8-4V14a2 2 0 002 2h12a2 2 0 002-2V8.118z" />
+                    </svg>
+                  </button>
+                  <span>{player.name}</span>
+                </div>
+                <div className="flex-none">
+                  <span className="place-self-end">
+                    <DateString format={DATE_FORMAT_SHORT} />
+                  </span>
+                </div>
               </div>
-              <div className="flex-none">
-                <span className="place-self-end">
-                  <DateString format={DATE_FORMAT_SHORT} />
-                </span>
-              </div>
+              <main className="min-h-90 px-7.5" id="content">
+                {children}
+              </main>
             </div>
-            <main className="min-h-90 px-7.5" id="content">
-              {children}
-            </main>
           </div>
         </div>
       </div>
-    </div>
+    </body>
   );
 }

--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -5,17 +5,13 @@ import { app, player } from "@/lib/config";
 import packageJSON from "@/package.json";
 import morilinkLogo from "@/public/images/MoriLink_Logo.svg";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "About";
 const themeColor = "#dacca7";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 // Remove the leading caret (^) and tilde (~) notations from the version string

--- a/app/(pages)/calendar/page.tsx
+++ b/app/(pages)/calendar/page.tsx
@@ -14,6 +14,7 @@ import type { Metadata, Viewport } from "next";
 
 const title = "Calendar";
 const themeColor = "#f9db97";
+const backgroundColor = "#fdfdf5";
 
 export const metadata: Metadata = {
   title,
@@ -25,7 +26,12 @@ export const viewport: Viewport = {
 
 export default function CalendarPage() {
   return (
-    <PageLayout title={title} themeColor={themeColor} mainBackground="#fdfdf5">
+    <PageLayout
+      title={title}
+      themeColor={themeColor}
+      bodyBackground={backgroundColor}
+      mainBackground={backgroundColor}
+    >
       <div className="mx-auto flex max-w-xl flex-col gap-y-2.5 px-3 pt-3.75 pb-[calc(5rem+env(safe-area-inset-bottom))]">
         <Header />
         <div className="flex flex-col gap-y-1.5">

--- a/app/(pages)/calendar/page.tsx
+++ b/app/(pages)/calendar/page.tsx
@@ -10,7 +10,7 @@ import PlaceholderCard from "./PlaceholderCard";
 import ResidentBirthdaysCard from "./ResidentBirthdaysCard";
 import ZodiacSeasonCard from "./ZodiacSeasonCard";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "Calendar";
 const themeColor = "#f9db97";
@@ -18,10 +18,6 @@ const backgroundColor = "#fdfdf5";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export default function CalendarPage() {

--- a/app/(pages)/designs/[id]/page.tsx
+++ b/app/(pages)/designs/[id]/page.tsx
@@ -6,7 +6,7 @@ import PageLayout from "@/components/PageLayout";
 import { patterns } from "@/lib/config";
 import { generateImageURL, generatePatternThumbnailURL } from "@/lib/utils/image";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 import type { Pattern } from "@/lib/types/miscellaneous";
 
@@ -17,10 +17,6 @@ type Props = {
 const themeColor = "#fecad1";
 
 export const dynamicParams = false; // dynamic segments not included in generateStaticParams will return a 404
-
-export const viewport: Viewport = {
-  themeColor,
-};
 
 function getPattern(id: string): Pattern | undefined {
   return patterns.find((pattern) => pattern.id === id);

--- a/app/(pages)/designs/page.tsx
+++ b/app/(pages)/designs/page.tsx
@@ -18,7 +18,7 @@ export const viewport: Viewport = {
 
 export default async function CustomDesignsPage() {
   return (
-    <PageLayout title={title} themeColor={themeColor}>
+    <PageLayout title={title} themeColor={themeColor} bodyBackground={themeColor}>
       <div className="flex h-full flex-col justify-between gap-y-16">
         <div className="mx-auto w-full max-w-2xl px-5 pt-8">
           <CustomDesingsTabs

--- a/app/(pages)/designs/page.tsx
+++ b/app/(pages)/designs/page.tsx
@@ -3,17 +3,13 @@ import CustomDesignsGrid from "@/components/CustomDesignsGrid";
 import CustomDesingsTabs from "@/components/CustomDesignsTabs";
 import PageLayout from "@/components/PageLayout";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "Custom Designs";
 const themeColor = "#fecad1";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export default async function CustomDesignsPage() {

--- a/app/(pages)/gallery/[filename]/page.tsx
+++ b/app/(pages)/gallery/[filename]/page.tsx
@@ -6,7 +6,7 @@ import { DATE_FORMAT_FULL } from "@/lib/constants";
 import dayjs from "@/lib/utils/dayjs";
 import { generateImageURL, getGalleryImages } from "@/lib/utils/image";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 type Props = {
   params: Promise<{ filename: string }>;
@@ -17,10 +17,6 @@ const themeColor = "#ffd0ae";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export async function generateStaticParams() {

--- a/app/(pages)/gallery/page.tsx
+++ b/app/(pages)/gallery/page.tsx
@@ -4,17 +4,13 @@ import Link from "next/link";
 import PageLayout from "@/components/PageLayout";
 import { generateImageURL, getGalleryImages } from "@/lib/utils/image";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "Gallery";
 const themeColor = "#ffd0ae";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export default async function GalleryPage() {

--- a/app/(pages)/map/page.tsx
+++ b/app/(pages)/map/page.tsx
@@ -35,7 +35,12 @@ export default function MapPage() {
   const mapUpdateDate = dayjs(map.created_at).format(DATE_FORMAT_MEDIUM);
 
   return (
-    <PageLayout title={title} themeColor={themeColor} mainBackground={themeColor}>
+    <PageLayout
+      title={title}
+      themeColor={themeColor}
+      bodyBackground={themeColor}
+      mainBackground={themeColor}
+    >
       <div className="mx-auto flex h-full max-w-2xl flex-col items-center justify-center gap-y-9 px-5 pt-9 pb-[calc(4.5rem+env(safe-area-inset-bottom))] tracking-tight">
         <h2 className="relative px-6 py-2.5 text-xl/none font-bold text-dark-bronze-coin/75 before:absolute before:inset-0 before:[border-inline:3px_solid_transparent] before:[border-top:40px_solid_#faea4a] sm:text-[1.375rem]/none sm:before:[border-top:42px_solid_#faea4a] md:px-8 md:py-3 md:text-2xl/none md:before:[border-top:48px_solid_#faea4a]">
           <span className="relative">{island.name}</span>

--- a/app/(pages)/map/page.tsx
+++ b/app/(pages)/map/page.tsx
@@ -7,7 +7,7 @@ import dayjs from "@/lib/utils/dayjs";
 import { generateImageURL, getLatestMap, getMapBackgroundColor } from "@/lib/utils/image";
 
 import type { TransformationOptions } from "cloudinary";
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "Map";
 
@@ -24,10 +24,6 @@ const themeColor = await getMapBackgroundColor(mapImageURL);
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export default function MapPage() {

--- a/app/(pages)/music/page.tsx
+++ b/app/(pages)/music/page.tsx
@@ -23,7 +23,12 @@ export const viewport: Viewport = {
 
 export default function MusicPage() {
   return (
-    <PageLayout title={title} themeColor={themeColor} mainBackground={themeColor}>
+    <PageLayout
+      title={title}
+      themeColor={themeColor}
+      bodyBackground={themeColor}
+      mainBackground={themeColor}
+    >
       <div className="px-safe pb-safe">
         <NowPlaying />
         <div className="mx-auto grid max-w-3xl grid-cols-2 gap-4 px-7 pt-22 pb-14 sm:grid-cols-3 sm:px-9 md:grid-cols-4 md:px-11">

--- a/app/(pages)/music/page.tsx
+++ b/app/(pages)/music/page.tsx
@@ -8,17 +8,13 @@ import PageLayout from "@/components/PageLayout";
 import Tooltips from "@/components/Tooltips";
 import kkSongs from "@/data/music/kk_slider.json";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "Music";
 const themeColor = "#def4b9";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export default function MusicPage() {

--- a/app/(pages)/passport/page.tsx
+++ b/app/(pages)/passport/page.tsx
@@ -15,17 +15,13 @@ import { getStarSign, getStarSignColour } from "@/lib/utils/star-sign";
 import { getVillager } from "@/lib/utils/villagers";
 import spriteTownIsland from "@/public/images/sprites/Town_Island.png";
 
-import type { Metadata, Viewport } from "next";
+import type { Metadata } from "next";
 
 const title = "Passport";
 const themeColor = "#b4e4b5";
 
 export const metadata: Metadata = {
   title,
-};
-
-export const viewport: Viewport = {
-  themeColor,
 };
 
 export default function PassportPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,7 +31,6 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: app.themeColor,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
 import "./globals.css";
 
-import clsx from "clsx";
 import { Nunito } from "next/font/google";
 
 import MusicProvider from "@/components/MusicProvider";
@@ -37,10 +36,8 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={clsx(nunito.className, "bg-alabaster")}>
-      <body>
-        <MusicProvider>{children}</MusicProvider>
-      </body>
+    <html lang="en" className={nunito.className}>
+      <MusicProvider>{children}</MusicProvider>
     </html>
   );
 }

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -18,17 +18,19 @@ export default function PageLayout({
   children,
 }: Props) {
   return (
-    <div
-      className="relative grid h-full min-h-dvh grid-rows-[auto_1fr]"
-      style={{
-        ["--theme-color" as any]: themeColor,
-        ["--main-background" as any]: mainBackground,
-      }}
-    >
-      <Navbar title={title} parentPage={parentPage} />
-      <main className={clsx("size-full [background:var(--main-background)]")} id="content">
-        {children}
-      </main>
-    </div>
+    <body>
+      <div
+        className="relative grid h-full min-h-dvh grid-rows-[auto_1fr]"
+        style={{
+          ["--theme-color" as any]: themeColor,
+          ["--main-background" as any]: mainBackground,
+        }}
+      >
+        <Navbar title={title} parentPage={parentPage} />
+        <main className={clsx("size-full [background:var(--main-background)]")} id="content">
+          {children}
+        </main>
+      </div>
+    </body>
   );
 }

--- a/components/PageLayout.tsx
+++ b/components/PageLayout.tsx
@@ -5,6 +5,7 @@ import Navbar from "./Navbar";
 type Props = {
   title: string;
   themeColor: string;
+  bodyBackground?: string;
   mainBackground?: string;
   parentPage?: string;
   children: React.ReactNode;
@@ -13,12 +14,13 @@ type Props = {
 export default function PageLayout({
   title,
   themeColor,
-  mainBackground = "transparent",
+  bodyBackground = "#f4f1e3", // bg-alabaster
+  mainBackground = "#f4f1e3", // bg-alabaster
   parentPage = "/",
   children,
 }: Props) {
   return (
-    <body>
+    <body style={{ backgroundColor: bodyBackground }}>
       <div
         className="relative grid h-full min-h-dvh grid-rows-[auto_1fr]"
         style={{


### PR DESCRIPTION
## Changes

- Remove redundant `themeColor` meta viewport configurations (`<meta name="theme-color">`) as it's no longer supported on Safari (iOS 26)
- Decouple `<body>` from `RootLayout` to `PageLayout` to allow body background color to be customizable on each page
- Add `bodyBackground` prop on `PageLayout`